### PR TITLE
Misc. modifications: Rotate in 0.25 degrees. Rotation input-action repeatable. Align compass with mini-map. Fix for bug #59 ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Lizenz: https://creativecommons.org/licenses/by-nc-sa/4.0/
 | <kbd>R Shift</kbd>+<kbd>Num -</kbd> / <kbd>Num +</kbd> | Fahrspurbreite verringern/erhöhen |
 | <kbd>R Strg</kbd>+<kbd>Einfg</kbd> / <kbd>Entf</kbd> | Fahrzeug eine Fahrspur nach rechts/links bewegen (ohne zu wenden) |
 | <kbd>R Strg</kbd>+<kbd>Bild-hoch</kbd> / <kbd>Bild-runter</kbd> | Fahrzeug/Spurausrichtung um 1° erhöhen/verringern |
-| <kbd>R Shift</kbd>+<kbd>Bild-hoch</kbd> / <kbd>Bild-runter</kbd> | Fahrzeug/Spurausrichtung um 90° erhöhen/verringern |
+| <kbd>R Shift</kbd>+<kbd>Bild-hoch</kbd> / <kbd>Bild-runter</kbd> | Fahrzeug/Spurausrichtung um 0.25° erhöhen/verringern |
 | <kbd>R Strg</kbd>+<kbd>R Shift</kbd>+<kbd>Bild-hoch</kbd> / <kbd>Bild-runter</kbd> | Fahrzeug/Spurausrichtung um 45° erhöhen/verringern |
 | <kbd>R Strg</kbd>+<kbd>Num *</kbd> | Durch verschiedene Modi für automatisierte Aktionen am Feldende wechseln |
 | <kbd>R Shift</kbd>+<kbd>Num /</kbd> / <kbd>Num *</kbd> | Durch verschiedene Abstände zum Feldende wechseln |
@@ -109,7 +109,7 @@ License: https://creativecommons.org/licenses/by-nc-sa/4.0/
 | <kbd>R Shift</kbd>+<kbd>Num -</kbd> / <kbd>Num +</kbd> | decrease/increase track width |
 | <kbd>R Ctrl</kbd>+<kbd>Insert</kbd> / <kbd>Delete</kbd> | move vehicle one track to the right/left without turning around |
 | <kbd>R Ctrl</kbd>+<kbd>PageUp</kbd> / <kbd>PageDown</kbd> | increase/decrease snap/track direction by 1° |
-| <kbd>R Shift</kbd>+<kbd>PageUp</kbd> / <kbd>PageDown</kbd> | increase/decrease snap/track direction by 90° |
+| <kbd>R Shift</kbd>+<kbd>PageUp</kbd> / <kbd>PageDown</kbd> | increase/decrease snap/track direction by 0.25° |
 | <kbd>R Ctrl</kbd>+<kbd>R Shift</kbd>+<kbd>PageUp</kbd> / <kbd>PageDown</kbd> | increase/decrease snap/track direction by 45° |
 | <kbd>R Ctrl</kbd>+<kbd>Num *</kbd> | cycle through the different headland modes |
 | <kbd>R Shift</kbd>+<kbd>Num /</kbd> / <kbd>Num *</kbd> | cycle through headland distances |

--- a/libUtils.lua
+++ b/libUtils.lua
@@ -41,7 +41,7 @@ end
 function libUtils:args_to_txt(...)
   local args = { ... }
   local txt = ""
-  local i, v
+  --local i, v
   for i, v in ipairs(args) do
     if i > 1 then
       txt = txt .. ", "

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -2,7 +2,7 @@
 <modDesc descVersion="92">
   <author>Majo76</author>
 
-  <version>1.1.3.1</version>
+  <version>1.1.3.999</version>
 
   <title>
     <de>EnhancedVehicle</de>

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -10,8 +10,8 @@
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE1_2"   text="EV: 将捕捉/跟踪方向减少1°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_1"   text="EV: 将捕捉/跟踪方向增加45°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_2"   text="EV: 将捕捉/跟踪方向减少45°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: 将捕捉/跟踪方向增加90°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: 将捕捉/跟踪方向减少90°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: 将捕捉/跟踪方向增加0.25°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: 将捕捉/跟踪方向减少0.25°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_CALC_WW"    text="EV: (重新)计算工作宽度"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_GRID_RESET" text="EV: (重新)计算轨道布局"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_LINES_MODE" text="EV: 更改线路显示模式"/>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -10,8 +10,8 @@
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE1_2"   text="EV: Sníží směr přichycení/stopu o 1°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_1"   text="EV: Zvyšuje směr přichycení/sledování o 45°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_2"   text="EV: Snižuje směr přichycení/sledování o 45°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Zvyšuje směr přichycení/sledování o 90°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Snižuje směr přichycení/sledování o 90°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Zvyšuje směr přichycení/sledování o 0.25°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Snižuje směr přichycení/sledování o 0.25°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_CALC_WW"    text="EV: Přepočet pracovní šířky"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_GRID_RESET" text="EV: Přepočet trasy"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_LINES_MODE" text="EV: Změna režimu zobrazení čar"/>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -10,8 +10,8 @@
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE1_2"   text="EV: Formindsk lås/spor retning med 1°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_1"   text="EV: Forøg lås/spor retning med 45°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_2"   text="EV: Formindsk lås/spor retning med 45°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Forøg lås/spor retning med 90°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Formindsk lås/spor retning med 90°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Forøg lås/spor retning med 0.25°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Formindsk lås/spor retning med 0.25°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_CALC_WW"    text="EV: (Gen)indlæs arbejds bredde"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_GRID_RESET" text="EV: (Gen)indlæs spor layout"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_LINES_MODE" text="EV: Ændre display mode af linier"/>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -10,8 +10,8 @@
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE1_2"   text="EV: Fahrtrichtung/Fahrspur verringern um 1°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_1"   text="EV: Fahrtrichtung/Fahrspur erhöhen um 45°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_2"   text="EV: Fahrtrichtung/Fahrspur verringern um 45°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Fahrtrichtung/Fahrspur erhöhen um 90°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Fahrtrichtung/Fahrspur verringern um 90°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Fahrtrichtung/Fahrspur erhöhen um 0.25°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Fahrtrichtung/Fahrspur verringern um 0.25°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_CALC_WW"    text="EV: Arbeitsbreite neu berechnen"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_GRID_RESET" text="EV: Fahrspuren (neu) berechnen/ausrichten"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_LINES_MODE" text="EV: Anzeigemodus der Linien wechseln"/>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -10,8 +10,8 @@
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE1_2"   text="EV: Decrease snap/track direction by 1°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_1"   text="EV: Increase snap/track direction by 45°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_2"   text="EV: Decrease snap/track direction by 45°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Increase snap/track direction by 90°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Decrease snap/track direction by 90°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Increase snap/track direction by 0.25°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Decrease snap/track direction by 0.25°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_CALC_WW"    text="EV: (Re)calculate working width"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_GRID_RESET" text="EV: (Re)calculate track layout"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_LINES_MODE" text="EV: Change display mode of lines"/>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -10,8 +10,8 @@
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE1_2"   text="EV: Disminuir Ángulo Pista en 1°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_1"   text="EV: Aumentar Ángulo Pista en 45°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_2"   text="EV: Disminuir Ángulo Pista en 45°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Aumentar Ángulo Pista en 90°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Disminuir Ángulo Pista en 90°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Aumentar Ángulo Pista en 0.25°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Disminuir Ángulo Pista en 0.25°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_CALC_WW"    text="EV: (Re)Calcular Ancho Trabajo"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_GRID_RESET" text="EV: (Re)Posiconar Cuadricula de Pistas"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_LINES_MODE" text="EV: Cambiar el modo de visualización de las líneas"/>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -10,8 +10,8 @@
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE1_2"   text="EV: Diminuer l'angle des rangs de 1°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_1"   text="EV: Augmenter l'angle des rangs de 45°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_2"   text="EV: Diminuer l'angle des rangs de 45°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Augmenter l'angle des rangs de 90°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Diminuer l'angle des rangs de 90°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Augmenter l'angle des rangs de 0.25°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Diminuer l'angle des rangs de 0.25°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_CALC_WW"    text="EV: (Re)calculer la largeur de travail"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_GRID_RESET" text="EV: (Re)calculer les rangs"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_LINES_MODE" text="EV: Changer le mode d'affichage des lignes"/>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -10,8 +10,8 @@
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE1_2"   text="EV: Haladási irány/sáv rögzítés szögének csökkentése 1°-kal"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_1"   text="EV: Haladási irány/sáv rögzítés szögének növelése 45°-kal"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_2"   text="EV: Haladási irány/sáv rögzítés szögének csökkentése 45°-kal"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Haladási irány/sáv rögzítés szögének növelése 90°-kal"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Haladási irány/sáv rögzítés szögének csökkentése 90°-kal"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Haladási irány/sáv rögzítés szögének növelése 0.25°-kal"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Haladási irány/sáv rögzítés szögének csökkentése 0.25°-kal"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_CALC_WW"    text="EV: Működési szélesség (újra)számolása"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_GRID_RESET" text="EV: Sáv elrendezés (újra)számolása"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_LINES_MODE" text="EV: Vonalak megjelenítési módjának módosítása"/>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -10,8 +10,8 @@
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE1_2"   text="EV: Decrementa la direzione marcia/corsia di 1°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_1"   text="EV: Incrementa la direzione marcia/corsia di 45°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_2"   text="EV: Decrementa la direzione marcia/corsia di 45°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Incrementa la direzione marcia/corsia di 90°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Decrementa la direzione di marcia/corsia di 90 °"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Incrementa la direzione marcia/corsia di 0.25°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Decrementa la direzione di marcia/corsia di 0.25°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_CALC_WW"    text="EV: (Ri)calcolare la larghezza di lavoro"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_GRID_RESET" text="EV: Riallineare le corsie"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_LINES_MODE" text="EV: Cambia la modalità di visualizzazione delle linee"/>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -10,8 +10,8 @@
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE1_2"   text="EV: Zmniejsz kierunek przyciągania/ścieżki o 1°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_1"   text="EV: Zwiększ kierunek przyciągania/ścieżki o 45°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_2"   text="EV: Zmniejsz kierunek przyciągania/ścieżki o 45°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Zwiększ kierunek przyciągania/ścieżki o 90°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Zmniejsz kierunek przyciągania/ścieżki o 90°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Zwiększ kierunek przyciągania/ścieżki o 0.25°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Zmniejsz kierunek przyciągania/ścieżki o 0.25°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_CALC_WW"    text="EV: (Ponownie) oblicz szerokość roboczą"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_GRID_RESET" text="EV: (Ponownie) oblicz wyświetlanie ścieżki"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_LINES_MODE" text="EV: Zmień tryb wyświetlania linii"/>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -10,8 +10,8 @@
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE1_2"   text="EV: Уменьшить направление привязки/трека на 1°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_1"   text="EV: Увеличить направление привязки/трека на 45°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_2"   text="EV: Уменьшить направление привязки/трека 45°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Увеличить направление привязки/трека на 90°"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Уменьшить направление привязки/трека 90°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Увеличить направление привязки/трека на 0.25°"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Уменьшить направление привязки/трека 0.25°"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_CALC_WW"    text="EV: Перерассчитать рабочую ширину"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_GRID_RESET" text="EV: Перерассчитать сетку треков"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_LINES_MODE" text="EV: Изменить режим отображения линий"/>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -10,8 +10,8 @@
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE1_2"   text="EV: Sabitlenmiş yön derecesini 1° azalt"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_1"   text="EV: Sabitlenmiş yön derecesini 45° artır"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE2_2"   text="EV: Sabitlenmiş yön derecesini 45° azalt"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Sabitlenmiş yön derecesini 90° artır"/>
-    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Sabitlenmiş yön derecesini 90° azalt"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_1"   text="EV: Sabitlenmiş yön derecesini 0.25° artır"/>
+    <text name="input_FS25_EnhancedVehicle_SNAP_ANGLE3_2"   text="EV: Sabitlenmiş yön derecesini 0.25° azalt"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_CALC_WW"    text="EV: Çalışma genişliğini (yeniden) hesapla"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_GRID_RESET" text="EV: Hat düzenini (yeniden) hesapla"/>
     <text name="input_FS25_EnhancedVehicle_SNAP_LINES_MODE" text="EV: Çizgilerin görüntülenme modunu değiştir"/>

--- a/ui/FS25_EnhancedVehicle_UI.lua
+++ b/ui/FS25_EnhancedVehicle_UI.lua
@@ -64,9 +64,9 @@ function FS25_EnhancedVehicle_UI:onOpen()
 
   -- global elements
   for _, v in pairs(EV_elements_global) do
-    v1 = v.."Title"
-    v2 = v.."TT"
-    v3 = v.."Setting"
+    local v1 = v.."Title"
+    local v2 = v.."TT"
+    local v3 = v.."Setting"
     self[v1]:setText(g_i18n.modEnvironments[modName]:getText("ui_FS25_EnhancedVehicle_"..v1))
     self[v2]:setText(g_i18n.modEnvironments[modName]:getText("ui_FS25_EnhancedVehicle_"..v2))
     self[v3]:setTexts({
@@ -140,9 +140,9 @@ function FS25_EnhancedVehicle_UI:onOpen()
 
   -- HUD elements
   for _, v in pairs(EV_elements_HUD) do
-    v1 = "HUD"..v.."Title"
-    v2 = "HUD"..v.."TT"
-    v3 = "HUD"..v.."Setting"
+    local v1 = "HUD"..v.."Title"
+    local v2 = "HUD"..v.."TT"
+    local v3 = "HUD"..v.."Setting"
     self[v1]:setText(g_i18n.modEnvironments[modName]:getText("ui_FS25_EnhancedVehicle_"..v1))
     self[v2]:setText(g_i18n.modEnvironments[modName]:getText("ui_FS25_EnhancedVehicle_"..v2))
     self[v3]:setTexts({
@@ -167,13 +167,13 @@ end
 function FS25_EnhancedVehicle_UI:updateValues()
   -- global elements
   for _, v in pairs(EV_elements_global) do
-    v3 = v.."Setting"
+    local v3 = v.."Setting"
     self[v3]:setState(lC:getConfigValue("global.functions", v.."IsEnabled") and 1 or 2)
   end
 
   -- HUD elements
   for _, v in pairs(EV_elements_HUD) do
-    v3 = "HUD"..v.."Setting"
+    local v3 = "HUD"..v.."Setting"
     self[v3]:setState(lC:getConfigValue("hud."..v, "enabled") and 1 or 2)
   end
 
@@ -229,14 +229,14 @@ function FS25_EnhancedVehicle_UI:onClickOk()
 
   -- global functions
   for _, v in pairs(EV_elements_global) do
-    v1 = v.."Setting"
+    local v1 = v.."Setting"
     state = self[v1]:getState() == 1
     lC:setConfigValue("global.functions", v.."IsEnabled", state)
   end
 
   -- HUD
   for _, v in pairs(EV_elements_HUD) do
-    v1 = "HUD"..v.."Setting"
+    local v1 = "HUD"..v.."Setting"
     state = self[v1]:getState() == 1
     lC:setConfigValue("hud."..v, "enabled", state)
   end


### PR DESCRIPTION
Several changes merged into this commit:
- Ability to rotate in 0.25 degrees, instead of 90 degrees.
- Made rotation input-action repeatable similar to when setting width/offset of track.
- Display value of compass direction aligned to be the same as the base-game's mini-map.
- Reordered the "showLines" sequence: hidden -> yellow -> yellow & red -> red -> hidden.
- Fix for bug #59, other optimizations and reduction of same code-statements here and there.
- Avoidance of undeclared variables, more usage of `local`.